### PR TITLE
Fix issue with inlines

### DIFF
--- a/filer/static/filer/js/addons/dropzone.init.js
+++ b/filer/static/filer/js/addons/dropzone.init.js
@@ -147,8 +147,8 @@ django.jQuery(function ($) {
             Dropzone.autoDiscover = false;
         }
         dropzones.each(createDropzone);
-        $('.add-row a').on('click', function () {
-            var dropzones = $(dropzoneSelector);
+        $(document).on('formset:added', function (ev, row) {
+            var dropzones = $(row).find(dropzoneSelector);
             dropzones.each(createDropzone);
         });
     }


### PR DESCRIPTION
When dynamically adding dropzones (i.e. through inlines) they don't get initialized. This is caused by fix in baa8d52b31cf16d2145a2a8d9328ed74692dd361. Tested against Django 1.11.1 only.