### PR TITLE
Fix widget UI issue with Django 1.11

### DIFF
--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -43,7 +43,7 @@
 
             <br>
 
-            {{ hidden_input }}
+            <div class="hidden">{{ hidden_input }}</div>
             <script type="text/javascript" id="{{id}}_javascript">
                 django.jQuery(document).ready(function(){
                     var plus = django.jQuery('#add_{{ id }}');


### PR DESCRIPTION
In Django 1.11 admin the dropzone widget is not displayed properly -- it always shows an empty blue button next to the "Choose file" button.